### PR TITLE
[Feat] 유저, 카카오 로그인과 회원가입 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
-.env
+application-dev.properties
 
 ### STS ###
 .apt_generated

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -77,6 +76,22 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.7.0</version>
 		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.6</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.0.2</version>
+			<version>2.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
@@ -67,13 +63,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.springdoc</groupId>
-			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
 			<version>2.7.0</version>
 		</dependency>
 		<dependency>
@@ -99,14 +90,6 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/com/example/whenwhen/WhenwhenApplication.java
+++ b/src/main/java/com/example/whenwhen/WhenwhenApplication.java
@@ -1,12 +1,12 @@
 package com.example.whenwhen;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@OpenAPIDefinition
+@SpringBootApplication
 public class WhenwhenApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(WhenwhenApplication.class, args);
     }

--- a/src/main/java/com/example/whenwhen/config/AuthControllerDocs.java
+++ b/src/main/java/com/example/whenwhen/config/AuthControllerDocs.java
@@ -1,0 +1,44 @@
+package com.example.whenwhen.config;
+
+import com.example.whenwhen.dto.ApiResponseWrapper;
+import com.example.whenwhen.dto.EventRequestDto;
+import com.example.whenwhen.dto.EventResponseDto;
+import com.example.whenwhen.dto.LoginResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[Auth API]")
+public interface AuthControllerDocs {
+    @Operation(
+            summary = "카카오 로그인 URL 리다이렉트",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "302",
+                            description = "카카오 로그인 URL로 302 Redirect",
+                            headers = {
+                                    @Header(name = "Location", schema = @Schema(type = "string"))
+                            }
+                    )
+            }
+    )
+    public ResponseEntity<?> redirectKakaoLoginUrl();
+
+    @Operation(
+            summary = "카카오로 로그인 혹은 회원가입",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인/회원가입 성공",
+                            useReturnTypeSchema = true
+                    ),
+            }
+    )
+    public ResponseEntity<?> handleKakaoCallback(@RequestParam String code);
+}

--- a/src/main/java/com/example/whenwhen/config/EventControllerDocs.java
+++ b/src/main/java/com/example/whenwhen/config/EventControllerDocs.java
@@ -1,0 +1,81 @@
+package com.example.whenwhen.config;
+
+import com.example.whenwhen.dto.ApiResponseWrapper;
+import com.example.whenwhen.dto.EventRequestDto;
+import com.example.whenwhen.dto.EventResponseDto;
+import org.springframework.http.ResponseEntity;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "[Event API]")
+public interface EventControllerDocs {
+
+    @Operation(
+            summary = "Create a new event",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "이벤트 생성 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            implementation = ApiResponseWrapper.class,
+                                            subTypes = {EventResponseDto.class}
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "유효성 검증 실패",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(value = """
+                                            {
+                                                "success": false,
+                                                "error": {
+                                                    "code": "VALIDATION_ERROR",
+                                                    "message": "Invalid input data"
+                                                }
+                                            }
+                                            """))
+                    )
+            }
+    )
+    ResponseEntity<?> createEvent(EventRequestDto requestDto);
+
+    @Operation(
+            summary = "Retrieve event by code",
+            description = "이벤트 코드를 사용하여 이벤트 세부 정보를 검색합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "이벤트 세부 정보 검색 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            implementation = ApiResponseWrapper.class,
+                                            subTypes = {EventResponseDto.class}
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "이벤트를 찾을 수 없음",
+                            content = @Content(mediaType = "application/json",
+                                    examples = @ExampleObject(value = """
+                                            {
+                                              "success": false,
+                                              "error": {
+                                                "code": "EVENT_CODE_NOT_EXISTS",
+                                                "message": "존재하지 않는 이벤트 코드입니다."
+                                              }
+                                            }
+                                            """))
+                    )
+            }
+    )
+    ResponseEntity<?> getEventByCode(String eventCode);
+}

--- a/src/main/java/com/example/whenwhen/config/EventControllerDocs.java
+++ b/src/main/java/com/example/whenwhen/config/EventControllerDocs.java
@@ -15,51 +15,24 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface EventControllerDocs {
 
     @Operation(
-            summary = "Create a new event",
+            summary = "새 이벤트 생성",
             responses = {
                     @ApiResponse(
                             responseCode = "201",
                             description = "이벤트 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(
-                                            implementation = ApiResponseWrapper.class,
-                                            subTypes = {EventResponseDto.class}
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "유효성 검증 실패",
-                            content = @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(value = """
-                                            {
-                                                "success": false,
-                                                "error": {
-                                                    "code": "VALIDATION_ERROR",
-                                                    "message": "Invalid input data"
-                                                }
-                                            }
-                                            """))
+                            useReturnTypeSchema = true
                     )
             }
     )
     ResponseEntity<?> createEvent(EventRequestDto requestDto);
 
     @Operation(
-            summary = "Retrieve event by code",
-            description = "이벤트 코드를 사용하여 이벤트 세부 정보를 검색합니다.",
+            summary = "이벤트 코드로 이벤트 세부 정보 검색",
             responses = {
                     @ApiResponse(
                             responseCode = "200",
                             description = "이벤트 세부 정보 검색 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(
-                                            implementation = ApiResponseWrapper.class,
-                                            subTypes = {EventResponseDto.class}
-                                    )
-                            )
+                            useReturnTypeSchema = true
                     ),
                     @ApiResponse(
                             responseCode = "404",

--- a/src/main/java/com/example/whenwhen/config/SwaggerConfig.java
+++ b/src/main/java/com/example/whenwhen/config/SwaggerConfig.java
@@ -15,7 +15,6 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("WhenWhen API Documentation")
                         .version("v1")
-                        .description("API documentation for WhenWhen project")
                         .license(new License().name("Apache 2.0").url("http://springdoc.org")));
     }
 }

--- a/src/main/java/com/example/whenwhen/config/SwaggerConfig.java
+++ b/src/main/java/com/example/whenwhen/config/SwaggerConfig.java
@@ -14,7 +14,6 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("WhenWhen API Documentation")
-                        .version("v1")
-                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+                        .version("v1"));
     }
 }

--- a/src/main/java/com/example/whenwhen/config/WebClientConfig.java
+++ b/src/main/java/com/example/whenwhen/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.example.whenwhen.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder
+                .defaultHeader("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .build();
+    }
+}

--- a/src/main/java/com/example/whenwhen/controller/AuthController.java
+++ b/src/main/java/com/example/whenwhen/controller/AuthController.java
@@ -1,0 +1,41 @@
+package com.example.whenwhen.controller;
+
+import com.example.whenwhen.config.AuthControllerDocs;
+import com.example.whenwhen.dto.ApiResponseWrapper;
+import com.example.whenwhen.dto.LoginResponseDto;
+import com.example.whenwhen.service.AuthService;
+import com.example.whenwhen.service.KakaoAuthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController implements AuthControllerDocs {
+
+    private final AuthService authService;
+    private final KakaoAuthProvider kakaoAuthProvider;
+
+    @GetMapping("/kakao")
+    public ResponseEntity<Void> redirectKakaoLoginUrl() {
+        String redirectUrl = kakaoAuthProvider.getKakaoLoginRedirectUrl();
+
+        return ResponseEntity.status(302)
+                .header(HttpHeaders.LOCATION, redirectUrl)
+                .build();
+    }
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<ApiResponseWrapper<LoginResponseDto>> handleKakaoCallback(@RequestParam String code) {
+        LoginResponseDto loginResponseDto = authService.handleKakaoCallback(code);
+        return ResponseEntity.ok().body(
+                ApiResponseWrapper.<LoginResponseDto>builder()
+                        .success(true)
+                        .message("Login successful.")
+                        .data(loginResponseDto)
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/example/whenwhen/controller/EventController.java
+++ b/src/main/java/com/example/whenwhen/controller/EventController.java
@@ -1,24 +1,18 @@
 package com.example.whenwhen.controller;
 
+import com.example.whenwhen.config.EventControllerDocs;
 import com.example.whenwhen.dto.ApiResponseWrapper;
 import com.example.whenwhen.dto.EventRequestDto;
 import com.example.whenwhen.dto.EventResponseDto;
 import com.example.whenwhen.service.EventService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/events")
-@Tag(name = "[Event API]")
-public class EventController {
+public class EventController implements EventControllerDocs {
 
     private final EventService eventService;
 
@@ -26,38 +20,8 @@ public class EventController {
         this.eventService = eventService;
     }
 
-    // POST /events
+    @Override
     @PostMapping
-    @Operation(
-            summary = "Create a new event",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "이벤트 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(
-                                            implementation = ApiResponseWrapper.class,
-                                            subTypes = {EventResponseDto.class}
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "400",
-                            description = "유효성 검증 실패",
-                            content = @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(value = """
-                                            {
-                                                "success": false,
-                                                "error": {
-                                                    "code": "VALIDATION_ERROR",
-                                                    "message": "Invalid input data"
-                                                }
-                                            }
-                                            """))
-                    )
-            }
-    )
     public ResponseEntity<?> createEvent(@RequestBody @Valid EventRequestDto requestDto) {
         EventResponseDto eventResponseDto = eventService.createEvent(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(
@@ -69,58 +33,16 @@ public class EventController {
         );
     }
 
-    // TODO: wrapper 클래스 내의 data도 보이게 하기
-    // GET /events/{eventCode}
+    @Override
     @GetMapping("/{eventCode}")
-    @Operation(
-            summary = "Retrieve event by code",
-            description = "이벤트 코드를 사용하여 이벤트 세부 정보를 검색합니다.",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "이벤트 세부 정보 검색 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(
-                                            implementation = ApiResponseWrapper.class,
-                                            subTypes = {EventResponseDto.class}
-                                    )
-                            )
-                    ),
-                    @ApiResponse(
-                            responseCode = "404",
-                            description = "이벤트를 찾을 수 없음",
-                            content = @Content(mediaType = "application/json",
-                                    examples = @ExampleObject(value = """
-                                            {
-                                              "success": false,
-                                              "error": {
-                                                "code": "EVENT_CODE_NOT_EXISTS",
-                                                "message": "존재하지 않는 이벤트 코드입니다."
-                                              }
-                                            }
-                                            """))
-                    )
-            }
-    )
     public ResponseEntity<?> getEventByCode(@PathVariable String eventCode) {
-        try {
-            EventResponseDto eventResponseDto = eventService.getEventByCode(eventCode);
-            return ResponseEntity.ok().body(
-                    ApiResponseWrapper.<EventResponseDto>builder()
-                            .success(true)
-                            .message("Event retrieved successfully.")
-                            .data(eventResponseDto)
-                            .build()
-            );
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    ApiResponseWrapper.builder()
-                            .success(false)
-                            .message(e.getMessage())
-                            .data(null)
-                            .build()
-            );
-        }
+        EventResponseDto eventResponseDto = eventService.getEventByCode(eventCode);
+        return ResponseEntity.ok().body(
+                ApiResponseWrapper.<EventResponseDto>builder()
+                        .success(true)
+                        .message("Event retrieved successfully.")
+                        .data(eventResponseDto)
+                        .build()
+        );
     }
 }

--- a/src/main/java/com/example/whenwhen/controller/EventController.java
+++ b/src/main/java/com/example/whenwhen/controller/EventController.java
@@ -5,6 +5,7 @@ import com.example.whenwhen.dto.ApiResponseWrapper;
 import com.example.whenwhen.dto.EventRequestDto;
 import com.example.whenwhen.dto.EventResponseDto;
 import com.example.whenwhen.service.EventService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,17 +13,14 @@ import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/api/events")
+@RequiredArgsConstructor
 public class EventController implements EventControllerDocs {
 
     private final EventService eventService;
 
-    public EventController(EventService eventService) {
-        this.eventService = eventService;
-    }
-
     @Override
     @PostMapping
-    public ResponseEntity<?> createEvent(@RequestBody @Valid EventRequestDto requestDto) {
+    public ResponseEntity<ApiResponseWrapper<EventResponseDto>> createEvent(@RequestBody @Valid EventRequestDto requestDto) {
         EventResponseDto eventResponseDto = eventService.createEvent(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 ApiResponseWrapper.<EventResponseDto>builder()
@@ -35,7 +33,7 @@ public class EventController implements EventControllerDocs {
 
     @Override
     @GetMapping("/{eventCode}")
-    public ResponseEntity<?> getEventByCode(@PathVariable String eventCode) {
+    public ResponseEntity<ApiResponseWrapper<EventResponseDto>> getEventByCode(@PathVariable String eventCode) {
         EventResponseDto eventResponseDto = eventService.getEventByCode(eventCode);
         return ResponseEntity.ok().body(
                 ApiResponseWrapper.<EventResponseDto>builder()

--- a/src/main/java/com/example/whenwhen/dto/ApiResponseWrapper.java
+++ b/src/main/java/com/example/whenwhen/dto/ApiResponseWrapper.java
@@ -2,8 +2,11 @@ package com.example.whenwhen.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
 
 @Builder
+@Data
 @Schema(description = "API 공통 응답 형식")
 public class ApiResponseWrapper<T> {
 
@@ -13,6 +16,9 @@ public class ApiResponseWrapper<T> {
     @Schema(description = "응답 메시지", example = "Event created successfully.")
     private String message;
 
-    @Schema(description = "응답 데이터", implementation = EventResponseDto.class)
+    @Schema(description = "응답 데이터")
     private T data;
+
+    @Schema(description = "오류 코드")
+    private String errorCode;
 }

--- a/src/main/java/com/example/whenwhen/dto/ApiResponseWrapper.java
+++ b/src/main/java/com/example/whenwhen/dto/ApiResponseWrapper.java
@@ -2,9 +2,7 @@ package com.example.whenwhen.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Data;
 
-@Data
 @Builder
 @Schema(description = "API 공통 응답 형식")
 public class ApiResponseWrapper<T> {

--- a/src/main/java/com/example/whenwhen/dto/EventRequestDto.java
+++ b/src/main/java/com/example/whenwhen/dto/EventRequestDto.java
@@ -1,20 +1,21 @@
 package com.example.whenwhen.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Data;
 
 @Data
 public class EventRequestDto {
-    @NotBlank(message = "Title is required")
+    @NotBlank
     private String title;
 
-    @Min(value = 0, message = "Start hour must be at least 0")
-    @Max(value = 23, message = "Start hour must be at most 23")
-    @NotNull(message = "Start hour is required")
+    @NotNull
+    @Min(value = 0)
+    @Max(value = 23)
     private int startHour;
 
-    @Min(value = 0, message = "End hour must be at least 0")
-    @Max(value = 23, message = "End hour must be at most 23")
-    @NotNull(message = "End hour is required")
+    @NotNull
+    @Min(value = 0)
+    @Max(value = 23)
     private int endHour;
 }

--- a/src/main/java/com/example/whenwhen/dto/EventResponseDto.java
+++ b/src/main/java/com/example/whenwhen/dto/EventResponseDto.java
@@ -1,8 +1,13 @@
 package com.example.whenwhen.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
 
 @Builder
+@Data
+@Schema(description = "이벤트 응답 DTO")
 public class EventResponseDto {
     private String title;
     private String code;

--- a/src/main/java/com/example/whenwhen/dto/EventResponseDto.java
+++ b/src/main/java/com/example/whenwhen/dto/EventResponseDto.java
@@ -1,14 +1,12 @@
 package com.example.whenwhen.dto;
 
 import lombok.Builder;
-import lombok.Data;
 
-@Data
 @Builder
 public class EventResponseDto {
     private String title;
     private String code;
-    private int startHour; // 24시간 형식
-    private int endHour;   // 24시간 형식
+    private int startHour;
+    private int endHour;
     private String status;
 }

--- a/src/main/java/com/example/whenwhen/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/whenwhen/dto/LoginResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.whenwhen.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+@Builder
+@Data
+@Schema(description = "로그인 응답 DTO")
+public class LoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType;
+    private String accountName;
+    private String thumbnailImageUrl;
+}

--- a/src/main/java/com/example/whenwhen/entity/Event.java
+++ b/src/main/java/com/example/whenwhen/entity/Event.java
@@ -8,14 +8,13 @@ import java.time.Instant;
 @Entity
 @Table(name = "events")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Event {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;  // 기본 키
+    private Long id;  // PK
 
     @Column(nullable = false)
     private String title;  // 이벤트 제목

--- a/src/main/java/com/example/whenwhen/entity/Event.java
+++ b/src/main/java/com/example/whenwhen/entity/Event.java
@@ -23,10 +23,10 @@ public class Event {
     @Column(unique = true, nullable = false)
     private String code;  // 초대 코드
 
-    @Column(name = "start_hour", nullable = false)
+    @Column(nullable = false)
     private int startHour;  // 일별 시작 시간
 
-    @Column(name = "end_hour", nullable = false)
+    @Column(nullable = false)
     private int endHour;  // 일별 종료 시간
 
 
@@ -38,16 +38,16 @@ public class Event {
         ACTIVE, COMPLETED
     }
 
-    @Column(name = "created_at", updatable = false)
+    @Column(updatable = false)
     private LocalDateTime createdAt;  // 생성 시간
 
     @PrePersist
-    public void prePersist() {
-        if (status == null) {
-            status = Status.ACTIVE;
+    public void onCreate() {
+        if (this.status == null) {
+            this.status = Status.ACTIVE;
         }
-        if (createdAt == null) {
-            createdAt = LocalDateTime.now();
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
         }
     }
 }

--- a/src/main/java/com/example/whenwhen/entity/Event.java
+++ b/src/main/java/com/example/whenwhen/entity/Event.java
@@ -3,7 +3,7 @@ package com.example.whenwhen.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "events")
@@ -39,7 +39,7 @@ public class Event {
     }
 
     @Column(updatable = false)
-    private LocalDateTime createdAt;  // 생성 시간
+    private Instant createdAt;  // 생성 시간
 
     @PrePersist
     public void onCreate() {
@@ -47,7 +47,7 @@ public class Event {
             this.status = Status.ACTIVE;
         }
         if (this.createdAt == null) {
-            this.createdAt = LocalDateTime.now();
+            this.createdAt = Instant.now();
         }
     }
 }

--- a/src/main/java/com/example/whenwhen/entity/RefreshToken.java
+++ b/src/main/java/com/example/whenwhen/entity/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.example.whenwhen.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // PK
+
+    @Column(nullable = false)
+    private String refreshToken; // 리프레시 토큰
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 토큰 소유 유저
+}

--- a/src/main/java/com/example/whenwhen/entity/User.java
+++ b/src/main/java/com/example/whenwhen/entity/User.java
@@ -4,25 +4,29 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "users")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long id; // PK
 
     @Column(nullable = false)
-    private String accountName;
+    private String accountName; // 카카오 계정 닉네임
 
-    private String thumbnailUrl;
+    @Column(unique = true, nullable = false)
+    private String kakaoSub; // 유저 판별용 회원번호
 
-    private Instant createdAt;
+    private String thumbnailImageUrl; // 프로필 사진 링크
+
+    private Instant createdAt; // 생성 시간
 
     @PrePersist
     protected void onCreate() {
@@ -30,4 +34,7 @@ public class User {
             this.createdAt = Instant.now();
         }
     }
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<RefreshToken> refreshTokens = new ArrayList<>(); // 유저 소유 토큰 배열
 }

--- a/src/main/java/com/example/whenwhen/entity/User.java
+++ b/src/main/java/com/example/whenwhen/entity/User.java
@@ -1,0 +1,33 @@
+package com.example.whenwhen.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String accountName;
+
+    private String thumbnailUrl;
+
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (this.createdAt == null) {
+            this.createdAt = Instant.now();
+        }
+    }
+}

--- a/src/main/java/com/example/whenwhen/exception/EntityNotFoundException.java
+++ b/src/main/java/com/example/whenwhen/exception/EntityNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.whenwhen.exception;
+
+public class EntityNotFoundException extends RuntimeException {
+    public EntityNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/whenwhen/exception/EventNotFoundException.java
+++ b/src/main/java/com/example/whenwhen/exception/EventNotFoundException.java
@@ -1,7 +1,0 @@
-package com.example.whenwhen.exception;
-
-public class EventNotFoundException extends RuntimeException {
-    public EventNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/example/whenwhen/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whenwhen/exception/GlobalExceptionHandler.java
@@ -40,4 +40,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    // General Exception
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseWrapper<Void>> handleGeneralException(Exception ex) {
+        ApiResponseWrapper<Void> response = ApiResponseWrapper.<Void>builder()
+                .success(false)
+                .message("An unexpected error occurred: " + ex.getMessage())
+                .data(null)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 }

--- a/src/main/java/com/example/whenwhen/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/whenwhen/exception/GlobalExceptionHandler.java
@@ -12,10 +12,8 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    // EventNotFoundException
-    @ExceptionHandler(EventNotFoundException.class)
-    public ResponseEntity<ApiResponseWrapper<Void>> handleEventNotFoundException(EventNotFoundException ex) {
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ApiResponseWrapper<Void>> handleEventNotFoundException(EntityNotFoundException ex) {
         ApiResponseWrapper<Void> response = ApiResponseWrapper.<Void>builder()
                 .success(false)
                 .message(ex.getMessage())
@@ -25,7 +23,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
     }
 
-    // MethodArgumentNotValidException
+    // @Valid 예외
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponseWrapper<Map<String, String>>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
@@ -40,7 +38,6 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
-    // General Exception
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponseWrapper<Void>> handleGeneralException(Exception ex) {
         ApiResponseWrapper<Void> response = ApiResponseWrapper.<Void>builder()

--- a/src/main/java/com/example/whenwhen/repository/EventRepository.java
+++ b/src/main/java/com/example/whenwhen/repository/EventRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
-    Optional<Event> findByCode(String code); // 이벤트 코드로 이벤트를 조회
+    Optional<Event> findByCode(String code);
 }

--- a/src/main/java/com/example/whenwhen/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/whenwhen/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.whenwhen.repository;
+
+import com.example.whenwhen.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/example/whenwhen/repository/UserRepository.java
+++ b/src/main/java/com/example/whenwhen/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.whenwhen.repository;
+
+import com.example.whenwhen.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/whenwhen/repository/UserRepository.java
+++ b/src/main/java/com/example/whenwhen/repository/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoSub(String kakaoSub);
 }

--- a/src/main/java/com/example/whenwhen/service/AuthService.java
+++ b/src/main/java/com/example/whenwhen/service/AuthService.java
@@ -1,0 +1,73 @@
+package com.example.whenwhen.service;
+
+import com.example.whenwhen.dto.ApiResponseWrapper;
+import com.example.whenwhen.dto.LoginResponseDto;
+import com.example.whenwhen.entity.RefreshToken;
+import com.example.whenwhen.entity.User;
+import com.example.whenwhen.repository.RefreshTokenRepository;
+import com.example.whenwhen.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final KakaoAuthProvider kakaoAuthProvider;
+
+    /**
+     * 카카오 로그인, 회원가입을 처리
+     * @param code 클라이언트로부터 받은 카카오 인가 코드
+     * @return {@link LoginResponseDto} 반환
+     */
+    @Transactional
+    public LoginResponseDto handleKakaoCallback(String code) {
+        // 1. 카카오 액세스 토큰 획득
+        Map<String, Object> kakaoAccessToken = kakaoAuthProvider.getKakaoToken(code);
+        String idToken = (String) kakaoAccessToken.get("id_token");
+
+        // 2. 카카오 사용자 정보 조회
+        Map<String, Object> userInfo = kakaoAuthProvider.decodeIdTokenToUserInfo(idToken);
+
+        String sub = (String) userInfo.get("sub");
+        String accountName = (String) userInfo.get("nickname");
+        String thumbnailImageUrl = (String) userInfo.get("profile_image_url");
+
+        // 3. 기존 사용자 조회 또는 신규 사용자 생성
+        User user = userRepository.findByKakaoSub(sub)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .kakaoSub(sub)
+                                .accountName(accountName)
+                                .thumbnailImageUrl(thumbnailImageUrl)
+                                .build()
+                ));
+
+        // 4. 애플리케이션 액세스/리프레시 토큰 생성 및 저장
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId());
+        String refreshToken = jwtTokenProvider.generateRefreshToken();
+
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .refreshToken(refreshToken)
+                        .user(user)
+                        .build()
+        );
+
+        // 5. LoginResponseDto 반환
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .tokenType("Bearer")
+                .accountName(accountName)
+                .thumbnailImageUrl(thumbnailImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/example/whenwhen/service/EventService.java
+++ b/src/main/java/com/example/whenwhen/service/EventService.java
@@ -3,7 +3,7 @@ package com.example.whenwhen.service;
 import com.example.whenwhen.dto.EventRequestDto;
 import com.example.whenwhen.dto.EventResponseDto;
 import com.example.whenwhen.entity.Event;
-import com.example.whenwhen.exception.EventNotFoundException;
+import com.example.whenwhen.exception.EntityNotFoundException;
 import com.example.whenwhen.repository.EventRepository;
 import com.example.whenwhen.util.CodeGenerator;
 import org.springframework.stereotype.Service;
@@ -19,7 +19,6 @@ public class EventService {
 
     // 이벤트 생성
     public EventResponseDto createEvent(EventRequestDto requestDto) {
-        // 랜덤 코드 생성
         String randomCode;
         do {
             randomCode = CodeGenerator.generateRandomCode();
@@ -46,7 +45,7 @@ public class EventService {
     // 코드로 이벤트 조회
     public EventResponseDto getEventByCode(String code) {
         Event event = eventRepository.findByCode(code)
-                .orElseThrow(() -> new EventNotFoundException("Event not found with code: " + code));
+                .orElseThrow(() -> new EntityNotFoundException("Event not found with code: " + code));
 
         return EventResponseDto.builder()
                 .title(event.getTitle())

--- a/src/main/java/com/example/whenwhen/service/JwtTokenProvider.java
+++ b/src/main/java/com/example/whenwhen/service/JwtTokenProvider.java
@@ -1,0 +1,63 @@
+package com.example.whenwhen.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long accessTokenValidity;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // 액세스 토큰 생성
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .subject(userId.toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + accessTokenValidity))
+                .signWith(secretKey) // 서명
+                .compact();
+    }
+
+    public String generateRefreshToken() {
+        return UUID.randomUUID().toString();
+    }
+
+    // 토큰 검증 및 사용자 ID 추출
+    public String validateAndExtractUserId(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("토큰이 만료되었습니다.", e);
+        } catch (SignatureException e) {
+            throw new IllegalArgumentException("유효하지 않은 서명입니다.", e);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("토큰 검증 중 오류가 발생했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/example/whenwhen/service/KakaoAuthProvider.java
+++ b/src/main/java/com/example/whenwhen/service/KakaoAuthProvider.java
@@ -1,0 +1,71 @@
+package com.example.whenwhen.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthProvider {
+
+    private final WebClient webClient;
+
+    @Value("${kakao.auth.client-id}")
+    private String clientId;
+
+    @Value("${kakao.auth.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${kakao.auth.scope}")
+    private String scope;
+
+    public String getKakaoLoginRedirectUrl() {
+        return "https://kauth.kakao.com/oauth/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&scope=" + scope;
+    }
+
+    // TODO: Map Warning 수정하기
+
+    /**
+     * 카카오로부터 액세스 토큰과 ID 토큰 등 획득
+     * @param code 카카오 OAuth에서 받은 인가 코드
+     * @return 액세스 토큰, ID 토큰 등
+     */
+    public Map<String, Object> getKakaoToken(String code) {
+        return webClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .bodyValue("grant_type=authorization_code"
+                        + "&client_id=" + clientId
+                        + "&redirect_uri=" + redirectUri
+                        + "&code=" + code)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    /**
+     * 카카오 액세스 토큰에 있는 ID 토큰을 디코딩하고 사용자 정보 반환
+     * @param idToken 카카오 ID 토큰
+     * @return Map 형식의 사용자 정보. sub, nickname, picture 등
+     */
+    public Map<String, Object> decodeIdTokenToUserInfo(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            ObjectMapper mapper = new ObjectMapper();
+            return mapper.readValue(payload, Map.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid ID token", e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,3 +1,0 @@
-SPRING_DATASOURCE_URL=jdbc:mysql://localhost:3306/whenwhen_database?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&zeroDateTimeBehavior=CONVERT_TO_NULL
-SPRING_DATASOURCE_USERNAME=root
-SPRING_DATASOURCE_PASSWORD=1349

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+kakao.auth.client-id=2ace9aa1d113cc518cd6ce99c64c0abb
+kakao.auth.redirect-uri=1
+kakao.auth.scope=openid,profile_nickname,profile_image


### PR DESCRIPTION
# 유저, kakao auth 구현
### Entity
- `User`
게스트가 아닌 카카오 로그인 유저의 정보를 저장하는 엔티티입니다
- `RefreshToken`
액세스 토큰 재발급 또는 로그아웃을 위해 카카오 유저의 RefreshToken을 저장하는 엔티티입니다

### DTO
- `LoginResponseDto`
카카오 로그인 성공 시 반환되는 DTO입니다

### Service
- `AuthService`
카카오 로그인과 회원가입 과정을 처리합니다.
    1. 유저가 로그인 이후 리다이렉트한 인가 코드를 받습니다
    2. 해당 인가 코드로 kakao auth에서 토큰과 사용자 정보를 받습니다
    3. 사용자 정보를 통해 회원가입 혹은 로그인합니다
    4. 액세스/리프레시 토큰과 유저 정보를 반환합니다
- `JwtTokenProvider`
애플리케이션에서 사용할 액세스/리프레시 토큰을 생성합니다
- `KakaoAuthProvider`
카카오 OAuth에 사용되는 URL과 토큰 기능을 제공합니다

### Controller
- `AuthController`
  1. 카카오 로그인 URL을 리다이렉트합니다
  2. 유저가 카카오 로그인을 마친 후 콜백된 인가 코드를 받아 AuthSevice로 넘겨줍니다.
  3. 토큰과 유저 정보를 반환합니다.

# 프로젝트 Swagger 문서 정리
- 컨트롤러의 스웨거 어노테이션을 별도의 interface로 분리하였습니다.
- 불필요한 어노테이션을 제거하였습니다.